### PR TITLE
Change to accept unknown server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When an unknown server was detected the release command would not
+  complete but there is no logical reason for that to happen as a change
+  log does not have to have a diff list. Instead if a server is unknown the
+  release command simply does not write the diff list.
+
 ## [1.2.1] - 2017-08-18
 
 ### Fixed

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/ReleaseMojo.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/ReleaseMojo.java
@@ -3,7 +3,7 @@ package org.enear.maven.plugins.keepachangelog;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.enear.maven.plugins.keepachangelog.git.GitServer;
+import org.enear.maven.plugins.keepachangelog.git.RepoServer;
 import org.enear.maven.plugins.keepachangelog.git.GitServerException;
 import org.enear.maven.plugins.keepachangelog.git.GitServerFactory;
 import org.enear.maven.plugins.keepachangelog.markdown.generic.RefLink;
@@ -64,13 +64,13 @@ public class ReleaseMojo extends InitMojo {
     /**
      * Writes a list of version comparison links.
      *
-     * @param gitServer the git server
+     * @param repoServer the git server
      * @param tagRange  the tag ranges.
      * @param bw        the buffered writer.
      * @throws IOException if an error occurs while writing.
      */
-    private void writeDiffLink(GitServer gitServer, Range<String> tagRange, BufferedWriter bw) throws IOException {
-        DiffRefLink diffRefLink = new DiffRefLink(tagFormat, gitServer, tagRange);
+    private void writeDiffLink(RepoServer repoServer, Range<String> tagRange, BufferedWriter bw) throws IOException {
+        DiffRefLink diffRefLink = new DiffRefLink(tagFormat, repoServer, tagRange);
         bw.write(diffRefLink.toMarkdown());
         bw.newLine();
     }
@@ -78,14 +78,16 @@ public class ReleaseMojo extends InitMojo {
     /**
      * Writes links to version differences based on tag ranges and a git server.
      *
-     * @param gitServer the git server where the URL will be used to write the Git version differences.
+     * @param repoServer the git server where the URL will be used to write the Git version differences.
      * @param bw        the writer for the updated changelog.
      * @throws IOException if an I/O error occurs.
      */
-    private void writeDiffLinks(GitServer gitServer, BufferedWriter bw) throws IOException {
-        List<Range<String>> tagRanges = getTagRanges();
-        for (Range<String> tagRange : tagRanges) {
-            writeDiffLink(gitServer, tagRange, bw);
+    private void writeDiffLinks(RepoServer repoServer, BufferedWriter bw) throws IOException {
+        if ( repoServer != null ) {
+            List<Range<String>> tagRanges = getTagRanges();
+            for (Range<String> tagRange : tagRanges) {
+                writeDiffLink(repoServer, tagRange, bw);
+            }
         }
     }
 
@@ -97,7 +99,7 @@ public class ReleaseMojo extends InitMojo {
      * @param path        the path of the changelog to update.
      * @throws MojoFailureException if an error occur.
      */
-    private void writeNewChangelog(String currVersion, GitServer gitServer,
+    private void writeNewChangelog(String currVersion, RepoServer gitServer,
                                    Path path) throws MojoFailureException {
         Path temp = createTempChangelog();
         try (BufferedWriter bw = Files.newBufferedWriter(temp)) {
@@ -169,7 +171,7 @@ public class ReleaseMojo extends InitMojo {
      * @return the origin repository.
      * @throws GitServerException if an error occurs while getting the origin repository.
      */
-    private GitServer getOriginRepo(URL url) {
+    private RepoServer getOriginRepo(URL url) {
         return GitServerFactory.from(url);
     }
 
@@ -229,7 +231,7 @@ public class ReleaseMojo extends InitMojo {
 
         Path path = getChangelogPath();
         String version = getAppVersion();
-        GitServer origin = getOriginRepo(connectionUrl);
+        RepoServer origin = getOriginRepo(connectionUrl);
         writeNewChangelog(version, origin, path);
     }
 

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/git/BaseGitServer.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/git/BaseGitServer.java
@@ -4,7 +4,7 @@ import org.enear.maven.plugins.keepachangelog.utils.Range;
 
 import java.net.URL;
 
-public abstract class BaseGitServer implements GitServer {
+public abstract class BaseGitServer implements RepoServer {
 
     @Override
     public URL diff(Range<String> range) {

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/git/BitBucketServer.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/git/BitBucketServer.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 /**
  * A BitBucket server representation.
  */
-public class BitBucketServer extends BaseGitServer implements GitServer {
+public class BitBucketServer extends BaseGitServer implements RepoServer {
 
     private static final String PROJECT_ID = "project";
     private static final String REPO_ID = "repository";

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/git/GitHubServer.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/git/GitHubServer.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class GitHubServer extends BaseGitServer implements GitServer {
+public class GitHubServer extends BaseGitServer implements RepoServer {
 
     private static final String USER_ID = "username";
     private static final String REPO_ID = "repository";

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/git/GitServerFactory.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/git/GitServerFactory.java
@@ -14,17 +14,17 @@ public class GitServerFactory {
      * Returns a Git Server based on a given repository URL.
      *
      * @param originUrl a repository URL.
-     * @return a Git Server.
+     * @return a Repository Server.
      * @throws GitServerException if the repository URL is malformed.
      */
-    public static GitServer from(URL originUrl) {
+    public static RepoServer from(URL originUrl) {
         String host = originUrl.getHost();
         if (host.startsWith(BITBUCKET_HOST_PREFIX)) {
             return new BitBucketServer(originUrl);
         } else if (host.startsWith(GITHUB_HOST_PREFIX)) {
             return new GitHubServer(originUrl);
         } else {
-            throw new GitServerException("Unknown Git server.");
+            return null;
         }
     }
 

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/git/RepoServer.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/git/RepoServer.java
@@ -7,7 +7,7 @@ import java.net.URL;
 /**
  * Represents a Git Server.
  */
-public interface GitServer {
+public interface RepoServer {
 
     /**
      * Returns an URL that compares two commits.

--- a/src/main/java/org/enear/maven/plugins/keepachangelog/markdown/specific/DiffRefLink.java
+++ b/src/main/java/org/enear/maven/plugins/keepachangelog/markdown/specific/DiffRefLink.java
@@ -1,6 +1,6 @@
 package org.enear.maven.plugins.keepachangelog.markdown.specific;
 
-import org.enear.maven.plugins.keepachangelog.git.GitServer;
+import org.enear.maven.plugins.keepachangelog.git.RepoServer;
 import org.enear.maven.plugins.keepachangelog.git.TagUtils;
 import org.enear.maven.plugins.keepachangelog.markdown.Markdown;
 import org.enear.maven.plugins.keepachangelog.markdown.generic.RefLink;
@@ -14,7 +14,7 @@ import java.net.URL;
 public class DiffRefLink implements Markdown {
 
     private String tagFormat;
-    private GitServer gitServer;
+    private RepoServer repoServer;
     private Range<String> versionRange;
 
     /**
@@ -24,9 +24,9 @@ public class DiffRefLink implements Markdown {
      * @param gitServer    the git server.
      * @param versionRange the version range.
      */
-    public DiffRefLink(String tagFormat, GitServer gitServer, Range<String> versionRange) {
+    public DiffRefLink(String tagFormat, RepoServer repoServer, Range<String> versionRange) {
         this.tagFormat = tagFormat;
-        this.gitServer = gitServer;
+        this.repoServer = repoServer;
         this.versionRange = versionRange;
     }
 
@@ -39,7 +39,7 @@ public class DiffRefLink implements Markdown {
     public String toMarkdown() {
         String end = versionRange.getEnd();
         Range<String> tagRange = TagUtils.toTagRange(tagFormat, versionRange);
-        URL diff = gitServer.diff(tagRange);
+        URL diff = repoServer.diff(tagRange);
         RefLink refLink = new RefLink(end, diff);
         return refLink.toMarkdown();
     }


### PR DESCRIPTION
When an unknown server was detected the release command would not
complete but there is no logical reason for that to happen as a change
log does not have to have a diff list. Instead if a server is unknown
the release command simply does not write the diff list.