### PR TITLE
Closes #11 different rangeUrl for unreleased version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Unreleased GitRef option. Allows the Unreleased link to compare to something else than HEAD. 
+
 ## [2.1.1] - 2020-02-21
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Unreleased GitRef option. Allows the Unreleased link to compare to something else than HEAD. 
+- Optional different Range URL for `Unreleased` link
 
 ## [2.1.1] - 2020-02-21
 

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/InitMojo.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/InitMojo.java
@@ -72,6 +72,9 @@ public class InitMojo extends AbstractMojo {
     @Parameter(defaultValue = "${settings}", readonly = true)
     protected Settings settings;
 
+    @Parameter(defaultValue = TagUtils.DEFAULT_UNRELEASED_GITREF, readonly = true)
+    protected String unreleasedGitRef;
+
     @Parameter(defaultValue = TagUtils.DEFAULT_TAG_FORMAT, readonly = true)
     protected String tagFormat;
 

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/InitMojo.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/InitMojo.java
@@ -56,9 +56,22 @@ public class InitMojo extends AbstractMojo {
 
     @Parameter(property = "repositoryUrl")
     protected URL repositoryUrl;
-    
+
+    /**
+     * A custom range URL. If defined it will be used to generate diff links.
+     * Requires a ${start} and ${end} variables, matching the reference range.
+     * Overrides the repositoryUrl when creating diff links.
+     * <p>
+     * Example: {@code}https://gitrepos.com/prj/compare/${start}..${end}{@code}
+     */
     @Parameter(property = "rangeUrl")
     protected String rangeUrl;
+
+    /**
+     * A custom range URL for the Unreleased link. Only used if {@link InitMojo#rangeUrl} is also supplied.
+     */
+    @Parameter(property = "rangeUrlUnreleased")
+    protected String rangeUrlUnreleased;
 
     @Parameter(property = "username")
     protected String username;
@@ -72,6 +85,11 @@ public class InitMojo extends AbstractMojo {
     @Parameter(defaultValue = "${settings}", readonly = true)
     protected Settings settings;
 
+    /**
+     * By default, the Unreleased link compares the latest released version with HEAD.
+     * This optional parameter allows to compare to something else instead of HEAD.
+     * That can be useful e.g. if you use the git-flow branching concept and thus want to compare the latest version with the develop branch.
+     */
     @Parameter(defaultValue = TagUtils.DEFAULT_UNRELEASED_GITREF, readonly = true)
     protected String unreleasedGitRef;
 

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/ReleaseMojo.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/ReleaseMojo.java
@@ -213,8 +213,8 @@ public class ReleaseMojo extends InitMojo {
      * @param rangeUrl a range URL
      * @return the repository server
      */
-    private RepoServer getRepoServer(String rangeUrl) {
-        return GitServerFactory.from(rangeUrl);
+    private RepoServer getRepoServer(String rangeUrl, String rangeUrlUnreleased) {
+        return GitServerFactory.from(rangeUrl, rangeUrlUnreleased);
     }
 
     /**
@@ -283,7 +283,7 @@ public class ReleaseMojo extends InitMojo {
         Path path = getChangelogPath();
         String version = getAppVersion();
         RepoServer origin = rangeUrl != null && !rangeUrl.isEmpty() ?
-                getRepoServer(rangeUrl) :
+                getRepoServer(rangeUrl, rangeUrlUnreleased) :
                 getOriginRepo(repositoryUrl);
         writeNewChangelog(version, origin, path);
     }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/ReleaseMojo.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/ReleaseMojo.java
@@ -100,7 +100,7 @@ public class ReleaseMojo extends InitMojo {
      * @throws IOException if an error occurs while writing.
      */
     private void writeDiffLink(RepoServer repoServer, Range<String> tagRange, BufferedWriter bw) throws IOException {
-        DiffRefLink diffRefLink = new DiffRefLink(tagFormat, repoServer, tagRange);
+        DiffRefLink diffRefLink = new DiffRefLink(tagFormat, unreleasedGitRef, repoServer, tagRange);
         bw.write(diffRefLink.toMarkdown());
         bw.newLine();
     }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/ValidateMojo.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/ValidateMojo.java
@@ -70,7 +70,7 @@ public class ValidateMojo extends InitMojo {
             logger.warn("Some versions in the changelog to not have a matching tag in the repository");
         }
         for (String version : versionsWithoutTags) {
-            String tag = toTag(tagFormat, version);
+            String tag = toTag(tagFormat, version, unreleasedGitRef);
             getLog().warn("Missing tag: " + tag);
         }
     }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/git/BaseGitServer.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/git/BaseGitServer.java
@@ -38,4 +38,16 @@ public abstract class BaseGitServer implements RepoServer {
         String end = range.getEnd();
         return diff(begin, end);
     }
+
+    @Override
+    public URL diffUnreleased(Range<String> range) {
+        String begin = range.getBegin();
+        String end = range.getEnd();
+        return diffUnreleased(begin, end);
+    }
+
+    @Override
+    public URL diffUnreleased(String a, String b) {
+        return diff(a, b);
+    }
 }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/git/CustomGitServer.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/git/CustomGitServer.java
@@ -12,10 +12,10 @@ package co.enear.maven.plugins.keepachangelog.git;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,14 +35,27 @@ import java.net.URL;
  * A custom Git server.
  * <p>
  * The diff URL requires two variables, {@code ${start}} and {@code ${end}}, that will represent a range. For example,
- * a valid GitHub range URL is shown bellow:
+ * a valid GitHub range URL is shown below:
  * <pre>
- * https://github.com/me/myproject/compare/${left}..${right}
+ * https://github.com/me/myproject/compare/${start}..${end}
  * </pre>
+ * This class optionally supports a different URL for the Unreleased link.
  */
 public class CustomGitServer extends BaseGitServer implements RepoServer {
 
     private String rangeUrl;
+    private String rangeUrlUnreleased;
+
+    /**
+     * Constructs a new custom Git server.
+     *
+     * @param rangeUrl the range URL with left and right variables
+     * @param rangeUrlUnreleased the range URL for Unreleased links with left and right variables
+     */
+    public CustomGitServer(String rangeUrl, String rangeUrlUnreleased) {
+        this.rangeUrl = rangeUrl;
+        this.rangeUrlUnreleased = rangeUrlUnreleased;
+    }
 
     /**
      * Constructs a new custom Git server.
@@ -51,12 +64,22 @@ public class CustomGitServer extends BaseGitServer implements RepoServer {
      */
     public CustomGitServer(String rangeUrl) {
         this.rangeUrl = rangeUrl;
+        this.rangeUrlUnreleased = rangeUrl;
     }
 
     @Override
     public URL diff(String a, String b) {
+        return diff(a, b, rangeUrl);
+    }
+
+    @Override
+    public URL diffUnreleased(String a, String b) {
+        return diff(a, b, rangeUrlUnreleased);
+    }
+
+    public URL diff(String a, String b, String customRangeUrl) {
         try {
-            String url = rangeUrl;
+            String url = customRangeUrl;
             url = StringUtils.replace(url, "start", a);
             url = StringUtils.replace(url, "end", b);
             return new URL(url);
@@ -64,5 +87,4 @@ public class CustomGitServer extends BaseGitServer implements RepoServer {
             throw new GitServerException("Failed to create a diff link.", e);
         }
     }
-
 }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/git/GitServerFactory.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/git/GitServerFactory.java
@@ -12,10 +12,10 @@ package co.enear.maven.plugins.keepachangelog.git;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,7 +35,7 @@ import java.net.URL;
  * A factory for constructing Git Server representations.
  */
 public class GitServerFactory {
-    
+
     public static final Logger logger = LoggerFactory.getLogger(GitServerFactory.class);
 
     private static final String BITBUCKET_HOST_PREFIX = "bitbucket";
@@ -47,12 +47,17 @@ public class GitServerFactory {
      * @param rangeUrl the range URL
      * @return a repository server
      */
-    public static RepoServer from(String rangeUrl) {
+    public static RepoServer from(String rangeUrl, String rangeUrlUnreleased) {
         if (rangeUrl == null) {
             return null;
         } else {
-            logger.info("Using range URL {}", rangeUrl);
-            return new CustomGitServer(rangeUrl);
+            if (rangeUrlUnreleased == null) {
+                logger.info("Using range URL {}", rangeUrl);
+                return new CustomGitServer(rangeUrl);
+            } else {
+                logger.info("Using range URL {} and unreleased range URL {}", rangeUrl, rangeUrlUnreleased);
+                return new CustomGitServer(rangeUrl, rangeUrlUnreleased);
+            }
         }
     }
 

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/git/RepoServer.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/git/RepoServer.java
@@ -53,4 +53,23 @@ public interface RepoServer {
      * @throws GitServerException if the URL construction fails.
      */
     URL diff(Range<String> range);
+
+    /**
+     * Returns an URL that compares two commits, one of them being the Unreleased version.
+     *
+     * @param a the first commit.
+     * @param b the second commit.
+     * @return an URL that compares two commits.
+     * @throws GitServerException if the URL construction fails.
+     */
+    URL diffUnreleased(String a, String b);
+
+    /**
+     * Returns an URL that compares a range of commits, one of them being the Unreleased version.
+     *
+     * @param range the range of commits.
+     * @return an URL that compares a range of commits.
+     * @throws GitServerException if the URL construction fails.
+     */
+    URL diffUnreleased(Range<String> range);
 }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/git/TagUtils.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/git/TagUtils.java
@@ -50,7 +50,7 @@ public class TagUtils {
     private static final String VERSION_ID = "version";
     public static final String DEFAULT_TAG_FORMAT = "v${" + VERSION_ID + "}";
 
-    private static final String HEAD = "HEAD";
+    public static final String DEFAULT_UNRELEASED_GITREF = "HEAD";
     private static final String REFS_TAGS = "refs/tags/";
 
     private static String getTagName(Ref tagRef) {
@@ -92,9 +92,9 @@ public class TagUtils {
      * @param version   the version to be converted.
      * @return a tag.
      */
-    public static String toTag(String tagFormat, String version) {
+    public static String toTag(String tagFormat, String version, String unreleasedGitRef) {
         if (version.equals(UNRELEASED_VERSION)) {
-            return HEAD;
+            return unreleasedGitRef;
         } else {
             return StringUtils.replace(tagFormat, VERSION_ID, version);
         }
@@ -107,9 +107,9 @@ public class TagUtils {
      * @param versionRange the version range.
      * @return a tag range.
      */
-    public static Range<String> toTagRange(String tagFormat, Range<String> versionRange) {
-        String b = toTag(tagFormat, versionRange.getBegin());
-        String e = toTag(tagFormat, versionRange.getEnd());
+    public static Range<String> toTagRange(String tagFormat, Range<String> versionRange, String unreleasedGitRef) {
+        String b = toTag(tagFormat, versionRange.getBegin(), unreleasedGitRef);
+        String e = toTag(tagFormat, versionRange.getEnd(), unreleasedGitRef);
         return new Range<>(b, e);
     }
 

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/markdown/specific/DiffRefLink.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/markdown/specific/DiffRefLink.java
@@ -34,6 +34,8 @@ import co.enear.maven.plugins.keepachangelog.git.TagUtils;
 
 import java.net.URL;
 
+import static co.enear.maven.plugins.keepachangelog.InitMojo.UNRELEASED_VERSION;
+
 /**
  * A changelog version comparison.
  */
@@ -67,7 +69,12 @@ public class DiffRefLink implements Markdown {
     public String toMarkdown() {
         String end = versionRange.getEnd();
         Range<String> tagRange = TagUtils.toTagRange(tagFormat, versionRange, unreleasedGitRef);
-        URL diff = repoServer.diff(tagRange);
+        URL diff;
+        if (versionRange.contains(UNRELEASED_VERSION)) {
+            diff = repoServer.diffUnreleased(tagRange);
+        } else {
+            diff = repoServer.diff(tagRange);
+        }
         RefLink refLink = new RefLink(end, diff);
         return refLink.toMarkdown();
     }

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/markdown/specific/DiffRefLink.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/markdown/specific/DiffRefLink.java
@@ -40,6 +40,7 @@ import java.net.URL;
 public class DiffRefLink implements Markdown {
 
     private String tagFormat;
+    private String unreleasedGitRef;
     private RepoServer repoServer;
     private Range<String> versionRange;
 
@@ -50,8 +51,9 @@ public class DiffRefLink implements Markdown {
      * @param repoServer   the repository server.
      * @param versionRange the version range.
      */
-    public DiffRefLink(String tagFormat, RepoServer repoServer, Range<String> versionRange) {
+    public DiffRefLink(String tagFormat, String unreleasedGitRef, RepoServer repoServer, Range<String> versionRange) {
         this.tagFormat = tagFormat;
+        this.unreleasedGitRef = unreleasedGitRef;
         this.repoServer = repoServer;
         this.versionRange = versionRange;
     }
@@ -64,7 +66,7 @@ public class DiffRefLink implements Markdown {
     @Override
     public String toMarkdown() {
         String end = versionRange.getEnd();
-        Range<String> tagRange = TagUtils.toTagRange(tagFormat, versionRange);
+        Range<String> tagRange = TagUtils.toTagRange(tagFormat, versionRange, unreleasedGitRef);
         URL diff = repoServer.diff(tagRange);
         RefLink refLink = new RefLink(end, diff);
         return refLink.toMarkdown();

--- a/src/main/java/co/enear/maven/plugins/keepachangelog/utils/Range.java
+++ b/src/main/java/co/enear/maven/plugins/keepachangelog/utils/Range.java
@@ -12,10 +12,10 @@ package co.enear.maven.plugins.keepachangelog.utils;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -117,5 +117,9 @@ public class Range<N> {
     @Override
     public int hashCode() {
         return Objects.hash(begin, end);
+    }
+
+    public boolean contains(N object) {
+        return begin.equals(object) || end.equals(object);
     }
 }

--- a/src/test/java/co/enear/maven/plugins/keepachangelog/git/TagUtilsTest.java
+++ b/src/test/java/co/enear/maven/plugins/keepachangelog/git/TagUtilsTest.java
@@ -50,19 +50,19 @@ public class TagUtilsTest {
 
     @Test
     public void should_GetTag_WhenGivenReleasedVersion() {
-        assertEquals("v1.0.0", TagUtils.toTag("v${version}", "1.0.0"));
+        assertEquals("v1.0.0", TagUtils.toTag("v${version}", "1.0.0", HEAD));
     }
 
     @Test
     public void should_GetHead_WhenGivenUnreleasedVersion() {
-        assertEquals(HEAD, TagUtils.toTag("", UNRELEASED_VERSION));
+        assertEquals(HEAD, TagUtils.toTag("", UNRELEASED_VERSION, HEAD));
     }
 
     @Test
     public void should_GetTagRange_WhenGivenReleasedVersionRange() {
         Range<String> range = new Range<String>("0.0.0", "3.0.0");
 
-        Range<String> actual = TagUtils.toTagRange("v${version}", range);
+        Range<String> actual = TagUtils.toTagRange("v${version}", range, HEAD);
 
         assertEquals("v0.0.0", actual.getBegin());
         assertEquals("v3.0.0", actual.getEnd());


### PR DESCRIPTION
This PR resolves #11 by adding two new config options to allow for a different URL for the diff link for the `Unreleased` version. This is needed if the branch workflow git-flow is used, where the unreleased link should compare the latest release tag or master to develop.

`unreleasedGitRef` replaces HEAD in the unreleased diff link. E.g. set this to `develop` to get this:
`[Unreleased]: https://github.com/user/reponame/compare/v2.1.1...develop`

`rangeUrlUnreleased` allows for a completly different diff url. For BitBucket Server (not cloud) set this to something like this:
`https://bitbucket.mycompany.com/projects/projectKey/repos/reponame/compare/diff?targetBranch=refs%2Fheads%2Fmaster&sourceBranch=refs%2Fheads%2Fdevelop`

Or to compare a version tag with develop:
`https://bitbucket.mycompany.com/projects/projectKey/repos/reponame/compare/diff?targetBranch=refs%2Ftags%2F${start}&sourceBranch=refs%2Fheads%2Fdevelop`